### PR TITLE
Make it easier to debug in the browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "criterion"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,8 +546,9 @@ dependencies = [
 
 [[package]]
 name = "rusfun"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
+ "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "gauss-quad 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -775,6 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 "checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
 "checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ndarray = "0.12.1"
 gauss-quad = "0.1.2"
 wasm-bindgen = "0.2.49"
 criterion = "0.2"
+console_error_panic_hook = "0.1.6"
 
 [[bench]]
 name = "quick_benchmark"

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -9,6 +9,13 @@ use crate::utils::array1_to_vec;
 
 use wasm_bindgen::prelude::*;
 
+extern crate console_error_panic_hook;
+
+#[wasm_bindgen]
+pub fn init_panic_hook() {
+    console_error_panic_hook::set_once();
+}
+
 /// Translates a string to a implemented function in rusfun to make them easily callable
 pub fn get_function(function_name: &str) -> fn(&Array1<f64>, &Array1<f64>) -> Array1<f64> {
     match function_name {
@@ -76,7 +83,7 @@ impl FitResult {
     pub fn chi2(&self) -> f64 {
         self.chi2
     }
-    
+
     pub fn redchi2(&self) -> f64 {
         self.redchi2
     }
@@ -90,7 +97,7 @@ impl FitResult {
     }
 }
 
-/// Fit using the LM algorithm for model named model_name using initial 
+/// Fit using the LM algorithm for model named model_name using initial
 /// parameters p, data (x, y, sy), fitting only where there is a non-zero
 /// value in vary_p
 #[wasm_bindgen]


### PR DESCRIPTION
expose console_error_panic_hook::set_once();

calling init_panic_hook from js will print any subsequent panic error messages in the console.